### PR TITLE
Legg til CODEOWNERS i .github-mappen

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @navikt/infotrygd @navikt/historisk-sheriff @navikt/infotek

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @navikt/infotrygd


### PR DESCRIPTION
Legger til CODEOWNERS i .github-mappen med riktig team, historisk-sheriff og @navikt/infotek som kodeeiere.